### PR TITLE
Issue#39: Fix Admin View

### DIFF
--- a/app/src/main/res/layout/item_admin_user.xml
+++ b/app/src/main/res/layout/item_admin_user.xml
@@ -2,7 +2,7 @@
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
+    android:layout_height="wrap_content"
     android:padding="12dp">
 
     <TextView


### PR DESCRIPTION
Fixes Admin Users list to display all users by correcting the RecyclerView item layout height.

**Details**
- Changed item_admin_user.xml root layout height from match_parent to wrap_content